### PR TITLE
Update README Arch section with maintained package

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,21 @@ sheldon add spaceship --github spaceship-prompt/spaceship-prompt
 
 <details>
 <summary>Arch</summary>
-Install the latest master from the AUR package [`spaceship-prompt-git`](https://aur.archlinux.org/packages/spaceship-prompt-git/):
+
+Install the latest release from the AUR package [spaceship-prompt](https://aur.archlinux.org/packages/spaceship-prompt/):
 
 ```
-git clone https://aur.archlinux.org/spaceship-prompt-git.git --depth=1
-cd spaceship-prompt-git
+git clone https://aur.archlinux.org/spaceship-prompt.git
+cd spaceship-prompt
 makepkg -si
 ```
+
+or using `yay`:
+```
+yay -S spaceship-prompt
+```
+
+Also there is an unmaintained git package [spaceship-prompt-git](https://aur.archlinux.org/packages/spaceship-prompt-git/).
 </details>
 
 <details>


### PR DESCRIPTION
Hey, I'm a maintainer of [spaceship-prompt](https://aur.archlinux.org/packages/spaceship-prompt) aur package. I noticed that [spaceship-prompt-git](https://aur.archlinux.org/packages/spaceship-prompt-git) package is no longer updated (e.g there is issue with `async.zsh` in installation) and seems like README should point this out. I changed the instructions to use `spaceship-prompt` package, because it has regular updates and working out of box a expected.  